### PR TITLE
Fix tests for uppercase log level in JSON

### DIFF
--- a/lib/formats/json.js
+++ b/lib/formats/json.js
@@ -7,6 +7,10 @@
  * @returns {string}
  */
 function json( log ) {
+  if ( typeof log.level === 'string' ) {
+    log = { ...log, level: log.level.toUpperCase() };
+  }
+
   return JSON.stringify( log );
 }
 

--- a/test/tests/lib/formats/json.js
+++ b/test/tests/lib/formats/json.js
@@ -24,6 +24,20 @@ describe( path, () => {
   } );
 
   it( 'should not serialize an Error', () => {
-    expect( formatJson( new Error('test') ) ).to.equal('{}');
+    const error =  new Error('test');
+    error.level = 'info';
+    expect( formatJson( error ) ).to.equal('{"level":"INFO"}');
+  } );
+
+  it( 'should uppercase the log level', () => {
+    const log = {
+      level: 'info',
+      timestamp: new Date().toISOString(),
+      message: 'Test message'
+    };
+
+    expect( formatJson( log ) ).to.equal(
+      JSON.stringify({ ...log, level: log.level.toUpperCase() })
+    );
   } );
 } );

--- a/test/tests/lib/logbro.js
+++ b/test/tests/lib/logbro.js
@@ -270,24 +270,21 @@ describe( path, () => {
       expect( this.data ).to.equal( format( expected ) + '\n' );
     } );
 
-    it( 'should emit an event with the log level and log object', () => {
+    it( 'should emit an event with the log level and log object', done => {
       const logger = new Logbro( this.opts );
       Logbro.level = 'trace';
       Logbro.format = 'json';
-      let eventData;
-      let formattedEventData;
-
-      logger.once( 'debug', ( formatted, log ) => {
-        eventData = log;
-        formattedEventData = formatted;
-      } );
 
       const args = [ 1, 'two', null, { four: 5, six: [ 7, '8' ] } ];
-      logger[ logWithFormat ]( 'debug', JSON.stringify, ...args );
       const expectedLog = buildLogObject( 'debug', args );
 
-      expect( eventData ).to.deep.equal( expectedLog );
-      expect( formattedEventData ).to.equal( logger.format( expectedLog ) );
+      logger.once( 'debug', ( formatted, log ) => {
+        expect( log ).to.deep.equal( expectedLog );
+        expect( formatted ).to.equal( logger.format( expectedLog ) );
+        done();
+      } );
+
+      logger[ logWithFormat ]( 'debug', formats.json, ...args );
     } );
   } );
 } );


### PR DESCRIPTION
For consistency with the `pretty` format, uppercase the log level in the `json` format.