### PR TITLE
Bug Fix: Logging was enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ your app is run with `NODE_DEBUG=warn node app.js`, all `warn`, `error`, and
 - `message` (string): an optional message. If the message is a format string, it will use the `interpolationValues` as the format parameters.
 - `[...interpolationValues]` (...any): optional values to use to format the `message` using `util.format()`. Otherwise, these values will be appended to the `message`.
 
-#### `bro.<level>(messages, [interpolationValues])`
+#### `bro.<level>(message, [interpolationValues])`
 
 The same as `bro.log`, but without the need to pass the `level` as a parameter. Prefer using these to `bro.log`.
 

--- a/lib/logbro.js
+++ b/lib/logbro.js
@@ -134,7 +134,7 @@ class Logbro extends EventEmitter {
     const levelValue = levels[ level ];
 
     // Ignore invalid or insufficient log levels
-    if ( levelValue === undefined || levelValue < levels[ this.level ]) {
+    if ( levelValue && this.level && levelValue < levels[ this.level ]) {
       return;
     }
 

--- a/lib/logbro.js
+++ b/lib/logbro.js
@@ -134,7 +134,11 @@ class Logbro extends EventEmitter {
     const levelValue = levels[ level ];
 
     // Ignore invalid or insufficient log levels
-    if ( levelValue && this.level && levelValue < levels[ this.level ]) {
+    if (
+      levelValue === undefined ||
+      this.level === undefined ||
+      levelValue < levels[ this.level ]
+    ) {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logbro",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tiny logging utility with events and streams",
   "keywords": [
     "logging",

--- a/test/tests/lib/logbro.js
+++ b/test/tests/lib/logbro.js
@@ -216,13 +216,20 @@ describe( path, () => {
   describe( '#logWithFormat', () => {
     beforeEach( () => {
       delete this.data;
-      const writable = new Writable();
-      writable._write = ( chunk, enc, next ) => {
+      delete this.error;
+      const stdout = new Writable();
+      stdout._write = ( chunk, enc, next ) => {
         this.data = chunk.toString();
         next();
       };
 
-      this.opts = { stdout: writable, stderr: writable };
+      const stderr = new Writable();
+      stderr._write = ( chunk, enc, next ) => {
+        this.error = chunk.toString();
+        next();
+      };
+
+      this.opts = { stdout, stderr };
     });
 
     before( () => {
@@ -258,6 +265,16 @@ describe( path, () => {
       ).to.be.undefined;
 
       expect( this.data ).to.equal('test\n');
+    } );
+
+    it( 'should log to stderr if loglevel <= 3', () => {
+      const logger = new Logbro( this.opts );
+      Logbro.level = 'info';
+      expect(
+        logger[ logWithFormat ]( 'error', () => 'test', 'message' )
+      ).to.be.undefined;
+
+      expect( this.error ).to.equal('test\n');
     } );
 
     it( 'should use util.buildLogObject with the level and args', () => {

--- a/test/tests/lib/logbro.js
+++ b/test/tests/lib/logbro.js
@@ -232,9 +232,12 @@ describe( path, () => {
 
     after( () => this.clock.restore() );
 
-    it( 'should do nothing if the level is invalid', () => {
+    it( 'should do nothing if level is undefined', () => {
       const logger = new Logbro( this.opts );
-      expect( logger[ logWithFormat ]('badlevel') ).to.be.undefined;
+      Logbro.level = undefined;
+      expect(
+        logger[ logWithFormat ]( 'error', JSON.stringify, 'message' )
+      ).to.be.undefined;
       expect( this.data ).to.be.undefined;
     } );
 


### PR DESCRIPTION
The old implementation did not check if the level is undefined. It is not possible to set the level to a bad level, but it is possible to set it to undefined. In addition, `level` defaults to `undefined` (the desired behavior if no `NODE_DEBUG` is set. Fix this by also checking `this.level`.

Also, add a test to ensure error logs to to `stderr`.